### PR TITLE
fix: Three.jsのパフォーマンス改善

### DIFF
--- a/src/About.jsx
+++ b/src/About.jsx
@@ -16,63 +16,61 @@ function About() {
 
     // camera
     const camera = new THREE.OrthographicCamera(
-      -sizes.width / 40,
-      sizes.width / 40,
-      sizes.height / 40,
-      -sizes.height / 40,
-      0.1,
-      100,
+      -sizes.width / 160,
+      sizes.width / 160,
+      sizes.height / 160,
+      -sizes.height / 160,
+      0,
+      1,
     );
     camera.position.set(0, 0, 0);
 
     // renderer
     const renderer = new THREE.WebGLRenderer({
         canvas: canvas,
-        antialias: true,
+        antialias: false,
         alpha: true,
+        premultipliedAlpha: false,
     });
     renderer.setSize(sizes.width, sizes.height);
     renderer.setPixelRatio(window.devicePixelRatio);
 
     // objects
-    // Python
     const pythonTexture = new THREE.TextureLoader().load('/skill/python.png');
-    const pythonGeometry = new THREE.SphereGeometry( 4, 64, 32 );
-    const pythonMaterial = new THREE.MeshPhysicalMaterial({ map: pythonTexture });
-    const python = new THREE.Mesh( pythonGeometry, pythonMaterial );
-    python.position.set(2.5, 7, -25);
+    const flaskTexture = new THREE.TextureLoader().load('/skill/flask.png');
+    const railsTexture = new THREE.TextureLoader().load('/skill/rails.png');
+    const reactTexture = new THREE.TextureLoader().load('/skill/react.png');
+    const awsTexture = new THREE.TextureLoader().load('/skill/aws.png');
+    const sphereGeometry = new THREE.SphereGeometry( 1, 64, 32 );
+
+    // Python
+    const pythonMaterial = new THREE.MeshLambertMaterial({ map: pythonTexture });
+    const python = new THREE.Mesh( sphereGeometry, pythonMaterial );
+    python.position.set(0.625, 1.75, -1);
     scene.add(python);
 
     // Flask
-    const flaskTexture = new THREE.TextureLoader().load('/skill/flask.png');
-    const flaskGeometry = new THREE.SphereGeometry( 4, 64, 32 );
-    const flaskMaterial = new THREE.MeshPhysicalMaterial({ map: flaskTexture });
-    const flask = new THREE.Mesh( flaskGeometry, flaskMaterial );
-    flask.position.set(15, 7, -25);
+    const flaskMaterial = new THREE.MeshLambertMaterial({ map: flaskTexture });
+    const flask = new THREE.Mesh( sphereGeometry, flaskMaterial );
+    flask.position.set(3.75, 1.75, -1);
     scene.add(flask);
 
     // Rails
-    const railsTexture = new THREE.TextureLoader().load('/skill/rails.png');
-    const railsGeometry = new THREE.SphereGeometry( 4, 64, 32 );
-    const railsMaterial = new THREE.MeshPhysicalMaterial({ map: railsTexture });
-    const rails = new THREE.Mesh( railsGeometry, railsMaterial );
-    rails.position.set(2.5, -5.5, -25);
+    const railsMaterial = new THREE.MeshLambertMaterial({ map: railsTexture });
+    const rails = new THREE.Mesh( sphereGeometry, railsMaterial );
+    rails.position.set(0.625, -1.375, -1);
     scene.add(rails);
 
     // React
-    const reactTexture = new THREE.TextureLoader().load('/skill/react.png');
-    const reactGeometry = new THREE.SphereGeometry( 4, 64, 32 );
-    const reactMaterial = new THREE.MeshPhysicalMaterial({ map: reactTexture });
-    const react = new THREE.Mesh( reactGeometry, reactMaterial );
-    react.position.set(15, -5.5, -25);
+    const reactMaterial = new THREE.MeshLambertMaterial({ map: reactTexture });
+    const react = new THREE.Mesh( sphereGeometry, reactMaterial );
+    react.position.set(3.75, -1.375, -1);
     scene.add(react);
 
     // AWS
-    const awsTexture = new THREE.TextureLoader().load('/skill/aws.png');
-    const awsGeometry = new THREE.SphereGeometry( 4, 64, 32 );
-    const awsMaterial = new THREE.MeshPhysicalMaterial({ map: awsTexture });
-    const aws = new THREE.Mesh( awsGeometry, awsMaterial );
-    aws.position.set(27.5, -5.5, -25);
+    const awsMaterial = new THREE.MeshLambertMaterial({ map: awsTexture });
+    const aws = new THREE.Mesh( sphereGeometry, awsMaterial );
+    aws.position.set(6.875, -1.375, -1);
     scene.add(aws);
 
     // カーソル制御
@@ -91,11 +89,19 @@ function About() {
     scene.add(directionalLight);
 
     // animation
+    let frame;
+
     const animate = () => {
+      // FPSを30に下げる
+      frame++;
+      if (frame % 2 == 0) {
+        return;
+      }
+
       renderer.render(scene, camera);
 
       // カーソル制御
-      const target = new THREE.Vector3(-mouse.x/2, -mouse.y/2, 0);
+      const target = new THREE.Vector3(-mouse.x / 60, -mouse.y / 60, 0);
       target.unproject(camera);
       const direction = target.sub(camera.position).normalize();
 

--- a/src/Top.jsx
+++ b/src/Top.jsx
@@ -30,17 +30,17 @@ function Top() {
 
     // camera
     const camera = new THREE.PerspectiveCamera(
-      75,
+      70,
       sizes.width / sizes.height,
-      0.1,
-      100,
+      0.5,
+      1.5,
     );
     camera.position.set(0, 0, 0);
 
     // renderer
     const renderer = new THREE.WebGLRenderer({
         canvas: canvas,
-        antialias: true,
+        antialias: false,
         alpha: true,
         premultipliedAlpha: false,
     });
@@ -55,8 +55,8 @@ function Top() {
     displayLoader.load("/display/scene.gltf",(gltf)=>{
       const display = gltf.scene;
 
-      display.scale.set(3.2,3.2,3.2);
-      display.position.set(0,-0.59,-1);
+      display.scale.set(3, 3, 3);
+      display.position.set(0,-0.55,-1);
 
       displayWrap.add(display);
 
@@ -66,11 +66,19 @@ function Top() {
 
     // 平行光源
     const directionalLight = new THREE.DirectionalLight(0xffffff, 3);
-    directionalLight.position.set(0.45, 0.45, 1);
+    directionalLight.position.set(0.425, 0.425, 1);
     scene.add(directionalLight);
 
     // animation
+    let frame;
+
     const animate = () => {
+      // FPSを30に下げる
+      frame++;
+      if (frame % 2 == 0) {
+        return;
+      }
+
       renderer.render(scene, camera);
       requestAnimationFrame(animate);
     };

--- a/src/Works.jsx
+++ b/src/Works.jsx
@@ -49,14 +49,21 @@ function Works() {
 
   // スライドを表示する
   const openModal = () => {
-    if (workIndex.current === 0) {
+  switch (workIndex.current) {
+    case 0:
       setWorkZero(true);
-    } else if (workIndex.current === 1) {
+      break;
+    case 1:
       setWorkOne(true);
-    } else if (workIndex.current === 2) {
+      break;
+    case 2:
       setWorkTwo(true);
+      break;
+    default:
+      break;
     }
   };
+
 
   // スライドを非表示にする
   const closeModal = () => {
@@ -80,16 +87,16 @@ function Works() {
     const camera = new THREE.PerspectiveCamera(
       75,
       sizes.width / sizes.height,
-      0.1,
-      100,
+      3,
+      30,
     );
     camera.rotation.z = -Math.PI / 18;
-    camera.position.set(0, 3, 15);
+    camera.position.set(0, 0, 15);
 
     // renderer
     const renderer = new THREE.WebGLRenderer({
         canvas: canvas,
-        antialias: true,
+        antialias: false,
         alpha: true,
         premultipliedAlpha: false,
     });
@@ -107,22 +114,23 @@ function Works() {
     const texture3 = textureLoader.load('/works/coming-soon.png');
     const frontMaterial3 = new THREE.MeshBasicMaterial({ map: texture3 });
 
+    const boxGeometry = new THREE.BoxGeometry(3, 3, 0.25);
     const sideMaterial0 = new THREE.MeshBasicMaterial({ color: 0x06c755 });
     const sideMaterial1 = new THREE.MeshBasicMaterial({ color: 0x187fc4 });
     const sideMaterial2 = new THREE.MeshBasicMaterial({ color: 0x333333 });
     const commonMaterial = new THREE.MeshBasicMaterial({ color: 0xdddddd });
 
-    const mesh0 = new THREE.Mesh(new THREE.BoxGeometry(3, 3, 0.25), [sideMaterial0, sideMaterial0, sideMaterial0, sideMaterial0, frontMaterial0, sideMaterial0]);
-    const mesh1 = new THREE.Mesh(new THREE.BoxGeometry(3, 3, 0.25), [sideMaterial1, sideMaterial1, sideMaterial1, sideMaterial1, frontMaterial1, sideMaterial1]);
-    const mesh2 = new THREE.Mesh(new THREE.BoxGeometry(3, 3, 0.25), [sideMaterial2, sideMaterial2, sideMaterial2, sideMaterial2, frontMaterial2, sideMaterial2]);
-    const mesh3 = new THREE.Mesh(new THREE.BoxGeometry(3, 3, 0.25), [commonMaterial, commonMaterial, commonMaterial, commonMaterial, frontMaterial3, commonMaterial]);
-    const mesh4 = new THREE.Mesh(new THREE.BoxGeometry(3, 3, 0.25), [commonMaterial, commonMaterial, commonMaterial, commonMaterial, frontMaterial3, commonMaterial]);
-    const mesh5 = new THREE.Mesh(new THREE.BoxGeometry(3, 3, 0.25), [commonMaterial, commonMaterial, commonMaterial, commonMaterial, frontMaterial3, commonMaterial]);
+    const mesh0 = new THREE.Mesh(boxGeometry, [sideMaterial0, sideMaterial0, sideMaterial0, sideMaterial0, frontMaterial0, sideMaterial0]);
+    const mesh1 = new THREE.Mesh(boxGeometry, [sideMaterial1, sideMaterial1, sideMaterial1, sideMaterial1, frontMaterial1, sideMaterial1]);
+    const mesh2 = new THREE.Mesh(boxGeometry, [sideMaterial2, sideMaterial2, sideMaterial2, sideMaterial2, frontMaterial2, sideMaterial2]);
+    const mesh3 = new THREE.Mesh(boxGeometry, [commonMaterial, commonMaterial, commonMaterial, commonMaterial, frontMaterial3, commonMaterial]);
+    const mesh4 = new THREE.Mesh(boxGeometry, [commonMaterial, commonMaterial, commonMaterial, commonMaterial, frontMaterial3, commonMaterial]);
+    const mesh5 = new THREE.Mesh(boxGeometry, [commonMaterial, commonMaterial, commonMaterial, commonMaterial, frontMaterial3, commonMaterial]);
 
     const meshes = [mesh0, mesh1, mesh2, mesh3, mesh4, mesh5];
 
     meshes.forEach((mesh) => {
-      mesh.position.set(0, 3, 0);
+      mesh.position.set(0, 0, 0);
       mesh.rotation.set(0, 0, -Math.PI / 18);
       scene.add(mesh);
     });
@@ -131,19 +139,19 @@ function Works() {
     let rotationSpeed = 0;           // 回転速度 (radian/frame)
     let currentAngle = -4 * Math.PI; // 現在の回転角度
     let targetAngle = 0;             // 目標の回転角度
-    let rotationSmoothness = 0.05;   // 回転の滑らかさ
+    let rotationSmoothness = 0.045;  // 回転の滑らかさ
     const angleStep = Math.PI / 3;   // 一回の回転角度
 
     // クリックによる回転
     const rotationRight = () => {
-      rotationSmoothness = 0.075;
+      rotationSmoothness = 0.07;
       targetAngle += angleStep;
     };
     const arrowRightElement = document.querySelector('.arrow-right');
     arrowRightElement.addEventListener('click', rotationRight);
 
     const rotationLeft = () => {
-      rotationSmoothness = 0.05;
+      rotationSmoothness = 0.07;
       targetAngle -= angleStep;
     };
     const arrowLeftElement = document.querySelector('.arrow-left');
@@ -173,7 +181,14 @@ function Works() {
     rot();
 
     // animation
+    let frame;
     const animate = () => {
+      // FPSを30に下げる
+      frame++;
+      if (frame % 2 == 0) {
+        return;
+      }
+
       renderer.render(scene, camera);
       requestAnimationFrame(animate);
     };


### PR DESCRIPTION
# やったこと
- Geometryの再利用
- MeshBasicMaterialまたはMeshLambertMaterialのみに変更
- camera.near, farをギリギリに調整
- antialias: false
- FPSを30に下げる

# 参考
- https://www.kabuku.co.jp/developers/tthreejsperftips
- https://alaki.co.jp/blog/?p=3783